### PR TITLE
fix diff.sh when stampedfiles is empty

### DIFF
--- a/scripts/build.subr
+++ b/scripts/build.subr
@@ -937,7 +937,7 @@ printstamps () {
 	echo
 	echo "Values of build stamps, excluding library archive headers:"
 	cat ${WORKDIR}/stampvalues.new |
-	    grep -vE '.*/[0-9]* *[0-9]{10}  0     0     (0|100644)'
+	    grep -vE '.*/[0-9]* *[0-9]{10}  0     0     (0|100644)' || true
 }
 
 # Print a list of new updates, in order to allow the user to
@@ -1091,6 +1091,8 @@ unstamp () {
 			look "${C}|${SC}|${FP}|" ${WORKDIR}/$1-index	\
 			    >> ${WORKDIR}/$1-index-delete
 	        fi
+		rm ${TMPDIR}/old ${TMPDIR}/old.1 ${TMPDIR}/old.2
+		rm ${TMPDIR}/new ${TMPDIR}/new.1 ${TMPDIR}/new.2
 	    done
 
 	# Remove lines from $1-index and add new lines.
@@ -1125,8 +1127,6 @@ unstamp () {
 
 	# Clean up
 	rm ${WORKDIR}/$1-index-add ${WORKDIR}/$1-index-delete
-	rm ${TMPDIR}/old ${TMPDIR}/old.1 ${TMPDIR}/old.2
-	rm ${TMPDIR}/new ${TMPDIR}/new.1 ${TMPDIR}/new.2
 	nuke oldstamps
 }
 


### PR DESCRIPTION
Because this script is executed with "-e", it will exit early in a few
different places if stampedfiles just happens to be empty.

Sponsored by:	Axcient