### PR TITLE
Compatibility with "git diff" when deleting files

### DIFF
--- a/scripts/build.subr
+++ b/scripts/build.subr
@@ -396,16 +396,7 @@ extractworld () {
 applypatches () {
 	cd ${WORKDIR}/$1/usr/src
 	while read PATCH; do
-		patch -p0 < ${PATCHDIR}/${PATCH}
-		# Remove ".orig" files created by patch(1) and empty files
-		for file in $(perl -ne \
-		    'print("$1\n") if /^\+\+\+ (?:b\/|\.\/)?(\S+)(?:\s+[(0-9].*)?$/' < \
-		    ${PATCHDIR}/${PATCH}); do
-			echo ${file}.orig
-			if [ ! -s ${file} ]; then
-				echo ${file}
-			fi
-		done | xargs rm -f
+		patch -EV none -p0 < ${PATCHDIR}/${PATCH}
 	done < $2 > ${WORKDIR}/$1-patch.log 2>&1
 	cd -
 }


### PR DESCRIPTION
When a git revision deletes a file, `git diff --no-prefix` will generate a fragment like this:

```
diff --git contrib/tzdata/pacificnew contrib/tzdata/pacificnew
deleted file mode 100644
index 8403219f6236..000000000000
--- contrib/tzdata/pacificnew
+++ /dev/null
```

The patch command will correctly apply such a patch. However, the logic in applypatches that tries to delete patch's resulting backup files will attempt to delete both /dev/null.orig and /dev/null. Deleting the latter has obviously bad consequences.

To fix this bug, simply delete all of that logic, and instruct patch not to generate backup files in the first place.

Fixes #7
Sponsored by:	Axcient